### PR TITLE
LISA-538 Removed nav links entirely

### DIFF
--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -29,7 +29,7 @@
       navTitle = Some("Lifetime ISA"),
       navTitleLink = Some(routes.HomePage.home),
       showBetaLink = false,
-      navLinks = Some(headerNavLinks))
+      navLinks = None)
 }
 
 @afterHeader = {}


### PR DESCRIPTION
Having an empty Some() still showed the Menu toggle on mobile/tablet.