### PR TITLE
LISA-1032: Updated tax enrolment subscription check

### DIFF
--- a/app/connectors/TaxEnrolmentJsonFormats.scala
+++ b/app/connectors/TaxEnrolmentJsonFormats.scala
@@ -26,11 +26,11 @@ trait TaxEnrolmentJsonFormats {
   implicit val taxIdentifierFormats: OFormat[TaxEnrolmentIdentifier] = Json.format[TaxEnrolmentIdentifier]
 
   implicit val subscriptionReads: Reads[TaxEnrolmentSubscription] = (
-    (JsPath \ "created").read[String].map[DateTime](d => new DateTime(d)) and
-    (JsPath \ "lastModified").read[String].map[DateTime](d => new DateTime(d)) and
+    (JsPath \ "created").read[Long].map[DateTime](d => new DateTime(d)) and
+    (JsPath \ "lastModified").read[Long].map[DateTime](d => new DateTime(d)) and
     (JsPath \ "credId").read[String] and
     (JsPath \ "serviceName").read[String] and
-    (JsPath \ "identifiers").read[List[TaxEnrolmentIdentifier]] and
+    (JsPath \ "identifiers").read[List[TaxEnrolmentIdentifier]].orElse(Reads.pure(Nil)) and
     (JsPath \ "callback").read[String] and
     (JsPath \ "state").read[String](Reads.pattern("^(ERROR|SUCCESS|PENDING)$".r, "error.formatting.state")).map[TaxEnrolmentState] {
       case "ERROR" => TaxEnrolmentError
@@ -42,8 +42,8 @@ trait TaxEnrolmentJsonFormats {
   )(TaxEnrolmentSubscription.apply _)
 
   implicit val subscriptionWrites: Writes[TaxEnrolmentSubscription] = (
-    (JsPath \ "created").write[String].contramap[DateTime]{_.toString} and
-    (JsPath \ "lastModified").write[String].contramap[DateTime]{_.toString} and
+    (JsPath \ "created").write[Long].contramap[DateTime]{_.getMillis} and
+    (JsPath \ "lastModified").write[Long].contramap[DateTime]{_.getMillis} and
     (JsPath \ "credId").write[String] and
     (JsPath \ "serviceName").write[String] and
     (JsPath \ "identifiers").write[List[TaxEnrolmentIdentifier]] and

--- a/test/connectors/TaxEnrolmentJsonFormatsSpec.scala
+++ b/test/connectors/TaxEnrolmentJsonFormatsSpec.scala
@@ -17,6 +17,7 @@
 package connectors
 
 import models._
+import org.joda.time.DateTimeZone
 import org.scalatestplus.play.PlaySpec
 import play.api.data.validation.ValidationError
 import play.api.libs.json.{JsPath, Json}
@@ -33,7 +34,7 @@ class TaxEnrolmentJsonFormatsSpec extends PlaySpec with TaxEnrolmentJsonFormats 
 
         val sub = parsed.head
 
-        sub.created.toString mustBe "2016-01-25T15:44:17.496Z"
+        sub.created.withZone(DateTimeZone.UTC).toString() mustBe "2017-06-29T09:01:54.908Z"
         sub.state mustBe TaxEnrolmentPending
       }
       "given valid json with a error status" in {
@@ -53,6 +54,16 @@ class TaxEnrolmentJsonFormatsSpec extends PlaySpec with TaxEnrolmentJsonFormats 
         val sub = parsed.head
 
         sub.state mustBe TaxEnrolmentSuccess
+      }
+      "given valid json with identifiers set to null" in {
+        val parsed = Json.parse(testJsonNullIdentifiers).as[List[TaxEnrolmentSubscription]]
+
+        parsed.size mustBe 1
+
+        val sub = parsed.head
+
+        sub.state mustBe TaxEnrolmentPending
+        sub.identifiers mustBe Nil
       }
     }
 
@@ -78,8 +89,8 @@ class TaxEnrolmentJsonFormatsSpec extends PlaySpec with TaxEnrolmentJsonFormats 
   }
 
   private val testJson: String = """[{
-                           |    "created": "2016-01-25T15:44:17.496Z",
-                           |    "lastModified": "2016-01-25T16:44:17.496Z",
+                           |    "created": 1498726914908,
+                           |    "lastModified": 1498726914908,
                            |    "serviceName": "HMRC-ORG-LISA",
                            |    "identifiers": [
                            |        {
@@ -89,10 +100,21 @@ class TaxEnrolmentJsonFormatsSpec extends PlaySpec with TaxEnrolmentJsonFormats 
                            |    ],
                            |    "callback": "callback url",
                            |    "etmpId": "bp safe id",
-                           |
                            |    "credId": "X",
                            |    "state": "PENDING",
                            |    "groupIdentifier": "Z"
                            |}]""".stripMargin
+
+  private val testJsonNullIdentifiers: String = """[{
+                                                |    "created": 1498726914908,
+                                                |    "lastModified": 1498726914908,
+                                                |    "serviceName": "HMRC-ORG-LISA",
+                                                |    "identifiers": null,
+                                                |    "callback": "callback url",
+                                                |    "etmpId": "bp safe id",
+                                                |    "credId": "X",
+                                                |    "state": "PENDING",
+                                                |    "groupIdentifier": "Z"
+                                                |}]""".stripMargin
 
 }

--- a/test/connectors/UserDetailsConnectorSpec.scala
+++ b/test/connectors/UserDetailsConnectorSpec.scala
@@ -31,6 +31,8 @@ class UserDetailsConnectorSpec extends PlaySpec
   with MockitoSugar
   with GuiceOneAppPerSuite {
 
+  implicit val hc = HeaderCarrier()
+
   "Get User Details endpoint" must {
 
     "return whatever it receives" in {
@@ -45,7 +47,6 @@ class UserDetailsConnectorSpec extends PlaySpec
   }
 
   val mockHttpGet = mock[HttpGet]
-  implicit val hc = HeaderCarrier()
 
   object SUT extends UserDetailsConnector {
     override val httpGet = mockHttpGet


### PR DESCRIPTION
* Date reads now based on int of unix epoch, not iso string
* Identifiers array now nullable - will serialize as an empty list if null