### PR TITLE
LISA-1081: Added updated application status pages

### DIFF
--- a/app/config/frontendGlobal.scala
+++ b/app/config/frontendGlobal.scala
@@ -24,7 +24,7 @@ import play.api.mvc.Request
 import play.api.{Application, Configuration, Play}
 import play.twirl.api.Html
 import uk.gov.hmrc.crypto.ApplicationCrypto
-import uk.gov.hmrc.http.cache.client.{ShortLivedCache, ShortLivedHttpCaching}
+import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache, ShortLivedHttpCaching}
 import uk.gov.hmrc.play.audit.filters.FrontendAuditFilter
 import uk.gov.hmrc.play.config.{AppName, ControllerConfig, RunMode, ServicesConfig}
 import uk.gov.hmrc.play.filters.MicroserviceFilterSupport
@@ -78,4 +78,11 @@ object LisaShortLivedHttpCaching extends ShortLivedHttpCaching with AppName with
 object LisaShortLivedCache extends ShortLivedCache {
   override implicit lazy val crypto = ApplicationCrypto.JsonCrypto
   override lazy val shortLiveCache = LisaShortLivedHttpCaching
+}
+
+object LisaSessionCache extends SessionCache with AppName with ServicesConfig {
+  override lazy val http = WSHttp
+  override lazy val defaultSource = appName
+  override lazy val baseUri = baseUrl("cachable.session-cache")
+  override lazy val domain = getConfString("cachable.session-cache.domain", throw new Exception(s"Could not find config 'cachable.session-cache.domain'"))
 }

--- a/app/controllers/ApplicationSubmittedController.scala
+++ b/app/controllers/ApplicationSubmittedController.scala
@@ -42,7 +42,10 @@ trait ApplicationSubmittedController extends LisaBaseController {
   }
 
   def successful(): Action[AnyContent] = Action.async { implicit request =>
-    Future.successful(Ok(views.html.registration.application_successful("Z1234")))
+    sessionCache.fetchAndGetEntry[String]("lisaManagerReferenceNumber").flatMap {
+      case Some(lisaManagerReferenceNumber) =>
+        Future.successful(Ok(views.html.registration.application_successful(lisaManagerReferenceNumber)))
+    }
   }
   
   def rejected(): Action[AnyContent] = Action.async { implicit request =>

--- a/app/controllers/ApplicationSubmittedController.scala
+++ b/app/controllers/ApplicationSubmittedController.scala
@@ -26,8 +26,8 @@ import services.AuthorisationService
 import scala.concurrent.Future
 
 trait ApplicationSubmittedController extends LisaBaseController {
-  def get(email: String): Action[AnyContent] = Action.async { implicit request =>
-    val page = Future.successful(Ok(views.html.registration.application_submitted(email, "ABC1234")))
+  def get(email: String, subscriptionId: String): Action[AnyContent] = Action.async { implicit request =>
+    val page = Future.successful(Ok(views.html.registration.application_submitted(email, subscriptionId)))
 
     authorisedForLisa((_) => page, checkEnrolmentStates = false)
   }

--- a/app/controllers/ApplicationSubmittedController.scala
+++ b/app/controllers/ApplicationSubmittedController.scala
@@ -29,27 +29,33 @@ import scala.concurrent.Future
 trait ApplicationSubmittedController extends LisaBaseController {
 
   def get(): Action[AnyContent] = Action.async { implicit request =>
-    sessionCache.fetchAndGetEntry[ApplicationSent](ApplicationSent.cacheKey).flatMap {
-      case Some(application) =>
-        val page = Ok(views.html.registration.application_submitted(application.email, application.subscriptionId))
-
-        authorisedForLisa((_) => Future.successful(page), checkEnrolmentStates = false)
-    }
+    authorisedForLisa((_) => {
+      sessionCache.fetchAndGetEntry[ApplicationSent](ApplicationSent.cacheKey).flatMap {
+        case Some(application) =>
+          Future.successful(Ok(views.html.registration.application_submitted(application.email, application.subscriptionId)))
+      }
+    }, checkEnrolmentState = false)
   }
 
   def pending(): Action[AnyContent] = Action.async { implicit request =>
-    Future.successful(Ok(views.html.registration.application_pending()))
+    authorisedForLisa((_) => {
+      Future.successful(Ok(views.html.registration.application_pending()))
+    }, checkEnrolmentState = false)
   }
 
   def successful(): Action[AnyContent] = Action.async { implicit request =>
-    sessionCache.fetchAndGetEntry[String]("lisaManagerReferenceNumber").flatMap {
-      case Some(lisaManagerReferenceNumber) =>
-        Future.successful(Ok(views.html.registration.application_successful(lisaManagerReferenceNumber)))
-    }
+    authorisedForLisa((_) => {
+      sessionCache.fetchAndGetEntry[String]("lisaManagerReferenceNumber").flatMap {
+        case Some(lisaManagerReferenceNumber) =>
+          Future.successful(Ok(views.html.registration.application_successful(lisaManagerReferenceNumber)))
+      }
+    }, checkEnrolmentState = false)
   }
   
   def rejected(): Action[AnyContent] = Action.async { implicit request =>
-    Future.successful(Ok(views.html.registration.application_rejected()))
+    authorisedForLisa((_) => {
+      Future.successful(Ok(views.html.registration.application_rejected()))
+    }, checkEnrolmentState = false)
   }
 }
 

--- a/app/controllers/BusinessStructureController.scala
+++ b/app/controllers/BusinessStructureController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import config.LisaShortLivedCache
+import config.{LisaSessionCache, LisaShortLivedCache}
 import models._
 import play.api.Play.current
 import play.api.i18n.Messages.Implicits._
@@ -30,7 +30,7 @@ trait BusinessStructureController extends LisaBaseController {
 
   val get: Action[AnyContent] = Action.async { implicit request =>
     authorisedForLisa { (cacheId) =>
-      cache.fetchAndGetEntry[BusinessStructure](cacheId, BusinessStructure.cacheKey).map {
+      shortLivedCache.fetchAndGetEntry[BusinessStructure](cacheId, BusinessStructure.cacheKey).map {
         case Some(data) => Ok(views.html.registration.business_structure(BusinessStructure.form.fill(data)))
         case None => Ok(views.html.registration.business_structure(BusinessStructure.form))
       }
@@ -44,7 +44,7 @@ trait BusinessStructureController extends LisaBaseController {
           Future.successful(BadRequest(views.html.registration.business_structure(formWithErrors)))
         },
         data => {
-          cache.cache[BusinessStructure](cacheId, BusinessStructure.cacheKey, data)
+          shortLivedCache.cache[BusinessStructure](cacheId, BusinessStructure.cacheKey, data)
 
           handleRedirect(routes.OrganisationDetailsController.get().url)
         }
@@ -57,6 +57,7 @@ trait BusinessStructureController extends LisaBaseController {
 object BusinessStructureController extends BusinessStructureController {
   val config: Configuration = Play.current.configuration
   val env: Environment = Environment(Play.current.path, Play.current.classloader, Play.current.mode)
-  override val cache = LisaShortLivedCache
+  override val sessionCache = LisaSessionCache
+  override val shortLivedCache = LisaShortLivedCache
   override val authorisationService = AuthorisationService
 }

--- a/app/controllers/LisaBaseController.scala
+++ b/app/controllers/LisaBaseController.scala
@@ -35,12 +35,12 @@ trait LisaBaseController extends FrontendController
   val shortLivedCache: ShortLivedCache
   val authorisationService: AuthorisationService
 
-  def authorisedForLisa(callback: (String) => Future[Result], checkEnrolmentStates: Boolean = true)(implicit request: Request[AnyContent]): Future[Result] = {
+  def authorisedForLisa(callback: (String) => Future[Result], checkEnrolmentState: Boolean = true)(implicit request: Request[AnyContent]): Future[Result] = {
     authorisationService.userStatus flatMap {
       case UserNotLoggedIn => Future.successful(toGGLogin(FrontendAppConfig.loginCallback))
       case UserUnauthorised => Future.successful(Redirect(routes.ErrorController.accessDenied()))
       case user: UserAuthorised => {
-        if (checkEnrolmentStates) {
+        if (checkEnrolmentState) {
           user.enrolmentState match {
             case TaxEnrolmentPending => Future.successful(Redirect(routes.ApplicationSubmittedController.pending()))
             case TaxEnrolmentError => Future.successful(Redirect(routes.ApplicationSubmittedController.rejected()))

--- a/app/controllers/LisaBaseController.scala
+++ b/app/controllers/LisaBaseController.scala
@@ -44,7 +44,11 @@ trait LisaBaseController extends FrontendController
           user.enrolmentState match {
             case TaxEnrolmentPending => Future.successful(Redirect(routes.ApplicationSubmittedController.pending()))
             case TaxEnrolmentError => Future.successful(Redirect(routes.ApplicationSubmittedController.rejected()))
-            case TaxEnrolmentSuccess => Future.successful(Redirect(routes.ApplicationSubmittedController.successful()))
+            case TaxEnrolmentSuccess(lisaManagerReferenceNumber) => {
+              sessionCache.cache[String]("lisaManagerReferenceNumber", lisaManagerReferenceNumber)
+
+              Future.successful(Redirect(routes.ApplicationSubmittedController.successful()))
+            }
             case TaxEnrolmentDoesNotExist => callback(s"${user.internalId}-lisa-registration")
           }
         }

--- a/app/controllers/RosmController.scala
+++ b/app/controllers/RosmController.scala
@@ -16,12 +16,13 @@
 
 package controllers
 
-import config.LisaShortLivedCache
+import config.{LisaSessionCache, LisaShortLivedCache}
 import connectors.RosmJsonFormats
-import models.LisaRegistration
+import models.{ApplicationSent, LisaRegistration}
 import play.api.mvc.{Action, _}
 import play.api.{Configuration, Environment, Logger, Play}
 import services.{AuditService, AuthorisationService, RosmService}
+import uk.gov.hmrc.http.cache.client.SessionCache
 
 trait RosmController extends LisaBaseController
   with RosmJsonFormats {
@@ -40,7 +41,11 @@ trait RosmController extends LisaBaseController
               path = routes.RosmController.get().url,
               auditData = createAuditDetails(registrationDetails) ++ Map("subscriptionId" -> subscriptionId))
 
-            Redirect(routes.ApplicationSubmittedController.get(registrationDetails.yourDetails.email, subscriptionId))
+            val applicationSentVM = ApplicationSent(subscriptionId = subscriptionId, email = registrationDetails.yourDetails.email)
+
+            sessionCache.cache[ApplicationSent](ApplicationSent.cacheKey, applicationSentVM)
+
+            Redirect(routes.ApplicationSubmittedController.get())
           }
           case Left(error) => {
             Logger.info("Audit of Submission -> auditType = applicationNotReceived")
@@ -75,7 +80,8 @@ trait RosmController extends LisaBaseController
 object RosmController extends RosmController {
   val config: Configuration = Play.current.configuration
   val env: Environment = Environment(Play.current.path, Play.current.classloader, Play.current.mode)
-  override val cache = LisaShortLivedCache
+  override val sessionCache = LisaSessionCache
+  override val shortLivedCache = LisaShortLivedCache
   override val auditService = AuditService
   override val rosmService = RosmService
   override val authorisationService = AuthorisationService

--- a/app/controllers/RosmController.scala
+++ b/app/controllers/RosmController.scala
@@ -45,6 +45,8 @@ trait RosmController extends LisaBaseController
 
             sessionCache.cache[ApplicationSent](ApplicationSent.cacheKey, applicationSentVM)
 
+            shortLivedCache.remove(cacheId)
+
             Redirect(routes.ApplicationSubmittedController.get())
           }
           case Left(error) => {

--- a/app/controllers/RosmController.scala
+++ b/app/controllers/RosmController.scala
@@ -40,7 +40,7 @@ trait RosmController extends LisaBaseController
               path = routes.RosmController.get().url,
               auditData = createAuditDetails(registrationDetails) ++ Map("subscriptionId" -> subscriptionId))
 
-            Redirect(routes.ApplicationSubmittedController.get(registrationDetails.yourDetails.email))
+            Redirect(routes.ApplicationSubmittedController.get(registrationDetails.yourDetails.email, subscriptionId))
           }
           case Left(error) => {
             Logger.info("Audit of Submission -> auditType = applicationNotReceived")

--- a/app/controllers/SummaryController.scala
+++ b/app/controllers/SummaryController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import config.LisaShortLivedCache
+import config.{LisaSessionCache, LisaShortLivedCache}
 import play.api.Play.current
 import play.api.i18n.Messages.Implicits._
 import play.api.mvc.{Action, _}
@@ -40,6 +40,7 @@ trait SummaryController extends LisaBaseController {
 object SummaryController extends SummaryController {
   val config: Configuration = Play.current.configuration
   val env: Environment = Environment(Play.current.path, Play.current.classloader, Play.current.mode)
-  override val cache = LisaShortLivedCache
+  override val sessionCache = LisaSessionCache
+  override val shortLivedCache = LisaShortLivedCache
   override val authorisationService = AuthorisationService
 }

--- a/app/controllers/TradingDetailsController.scala
+++ b/app/controllers/TradingDetailsController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import config.LisaShortLivedCache
+import config.{LisaSessionCache, LisaShortLivedCache}
 import models._
 import play.api.Play.current
 import play.api.i18n.Messages.Implicits._
@@ -31,7 +31,7 @@ trait TradingDetailsController extends LisaBaseController {
   val get: Action[AnyContent] = Action.async { implicit request =>
     authorisedForLisa { (cacheId) =>
 
-      cache.fetchAndGetEntry[TradingDetails](cacheId, TradingDetails.cacheKey).map {
+      shortLivedCache.fetchAndGetEntry[TradingDetails](cacheId, TradingDetails.cacheKey).map {
         case Some(data) => Ok(views.html.registration.trading_details(TradingDetails.form.fill(data)))
         case None => Ok(views.html.registration.trading_details(TradingDetails.form))
       }
@@ -47,7 +47,7 @@ trait TradingDetailsController extends LisaBaseController {
           Future.successful(BadRequest(views.html.registration.trading_details(formWithErrors)))
         },
         data => {
-          cache.cache[TradingDetails](cacheId, TradingDetails.cacheKey, data)
+          shortLivedCache.cache[TradingDetails](cacheId, TradingDetails.cacheKey, data)
 
           handleRedirect(routes.YourDetailsController.get().url)
         }
@@ -61,6 +61,7 @@ trait TradingDetailsController extends LisaBaseController {
 object TradingDetailsController extends TradingDetailsController {
   val config: Configuration = Play.current.configuration
   val env: Environment = Environment(Play.current.path, Play.current.classloader, Play.current.mode)
-  override val cache = LisaShortLivedCache
+  override val sessionCache = LisaSessionCache
+  override val shortLivedCache = LisaShortLivedCache
   override val authorisationService = AuthorisationService
 }

--- a/app/controllers/YourDetailsController.scala
+++ b/app/controllers/YourDetailsController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import config.LisaShortLivedCache
+import config.{LisaSessionCache, LisaShortLivedCache}
 import models._
 import play.api.Play.current
 import play.api.i18n.Messages.Implicits._
@@ -31,7 +31,7 @@ trait YourDetailsController extends LisaBaseController {
   val get: Action[AnyContent] = Action.async { implicit request =>
     authorisedForLisa { (cacheId) =>
 
-      cache.fetchAndGetEntry[YourDetails](cacheId, YourDetails.cacheKey).map {
+      shortLivedCache.fetchAndGetEntry[YourDetails](cacheId, YourDetails.cacheKey).map {
         case Some(data) => Ok(views.html.registration.your_details(YourDetails.form.fill(data)))
         case None => Ok(views.html.registration.your_details(YourDetails.form))
       }
@@ -47,7 +47,7 @@ trait YourDetailsController extends LisaBaseController {
           Future.successful(BadRequest(views.html.registration.your_details(formWithErrors)))
         },
         data => {
-          cache.cache[YourDetails](cacheId, YourDetails.cacheKey, data)
+          shortLivedCache.cache[YourDetails](cacheId, YourDetails.cacheKey, data)
 
           handleRedirect(routes.SummaryController.get().url)
         }
@@ -61,6 +61,7 @@ trait YourDetailsController extends LisaBaseController {
 object YourDetailsController extends YourDetailsController {
   val config: Configuration = Play.current.configuration
   val env: Environment = Environment(Play.current.path, Play.current.classloader, Play.current.mode)
-  override val cache = LisaShortLivedCache
+  override val sessionCache = LisaSessionCache
+  override val shortLivedCache = LisaShortLivedCache
   override val authorisationService = AuthorisationService
 }

--- a/app/models/ApplicationSent.scala
+++ b/app/models/ApplicationSent.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.Json
+
+case class ApplicationSent(email: String, subscriptionId: String)
+
+object ApplicationSent {
+  implicit val formats = Json.format[ApplicationSent]
+
+  val cacheKey = "applicationSent"
+}

--- a/app/models/TaxEnrolment.scala
+++ b/app/models/TaxEnrolment.scala
@@ -32,7 +32,7 @@ case class TaxEnrolmentSubscription(
 trait TaxEnrolmentState
 case object TaxEnrolmentPending extends TaxEnrolmentState
 case object TaxEnrolmentError extends TaxEnrolmentState
-case object TaxEnrolmentSuccess extends TaxEnrolmentState
 case object TaxEnrolmentDoesNotExist extends TaxEnrolmentState
+case class TaxEnrolmentSuccess(lisaManagerReferenceNumber: String) extends TaxEnrolmentState
 
 case class TaxEnrolmentIdentifier(key: String, value: String)

--- a/app/models/TaxEnrolment.scala
+++ b/app/models/TaxEnrolment.scala
@@ -33,6 +33,7 @@ trait TaxEnrolmentState
 case object TaxEnrolmentPending extends TaxEnrolmentState
 case object TaxEnrolmentError extends TaxEnrolmentState
 case object TaxEnrolmentDoesNotExist extends TaxEnrolmentState
+case object TaxEnrolmentSuccess extends TaxEnrolmentState
 case class TaxEnrolmentSuccess(lisaManagerReferenceNumber: String) extends TaxEnrolmentState
 
 case class TaxEnrolmentIdentifier(key: String, value: String)

--- a/app/services/AuthorisationService.scala
+++ b/app/services/AuthorisationService.scala
@@ -42,8 +42,8 @@ trait AuthorisationService extends AuthorisedFunctions {
       userDetailsConnector.getUserDetails(userUri)(hc) flatMap { user =>
         val groupId = user.groupIdentifier.getOrElse(throw new RuntimeException("No groupIdentifier for user"))
 
-        taxEnrolmentService.getLisaSubscriptionState(groupId)(hc) map { state =>
-          UserAuthorised(userId, user, state)
+        taxEnrolmentService.getNewestLisaSubscription(groupId)(hc) map { sub =>
+          UserAuthorised(userId, user, if (sub.isEmpty) TaxEnrolmentDoesNotExist else sub.get.state)
         }
       }
     } recover {

--- a/app/services/TaxEnrolmentService.scala
+++ b/app/services/TaxEnrolmentService.scala
@@ -30,12 +30,12 @@ trait TaxEnrolmentService {
 
   val connector: TaxEnrolmentConnector
 
-  def getLisaSubscriptionState(groupId: String)(implicit hc:HeaderCarrier): Future[TaxEnrolmentState] = {
+  def getNewestLisaSubscription(groupId: String)(implicit hc:HeaderCarrier): Future[Option[TaxEnrolmentSubscription]] = {
     val response: Future[List[TaxEnrolmentSubscription]] = connector.getSubscriptionsByGroupId(groupId)(hc)
 
     response.map { l =>
       val subs = l.filter(sub => sub.serviceName == "HMRC-LISA-ORG")
-      if (subs.isEmpty) TaxEnrolmentDoesNotExist else subs.maxBy(sub => sub.created).state
+      if (subs.isEmpty) None else Some(subs.maxBy(sub => sub.created))
     }
   }
 

--- a/app/services/TaxEnrolmentService.scala
+++ b/app/services/TaxEnrolmentService.scala
@@ -35,7 +35,17 @@ trait TaxEnrolmentService {
 
     response.map { l =>
       val subs = l.filter(sub => sub.serviceName == "HMRC-LISA-ORG")
-      if (subs.isEmpty) None else Some(subs.maxBy(sub => sub.created))
+      if (subs.isEmpty) {
+        None
+      }
+      else {
+        val sub = subs.maxBy(sub => sub.created)
+
+        sub.state match {
+          case TaxEnrolmentSuccess => throw new RuntimeException("Invalid LISA subscription - successful status with no zref")
+          case _ => Some(sub)
+        }
+      }
     }
   }
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -13,7 +13,7 @@ GET        /your-details                    controllers.YourDetailsController.ge
 POST       /your-details                    controllers.YourDetailsController.post
 GET        /check-your-answers              controllers.SummaryController.get
 GET        /submit-registration             controllers.RosmController.get
-GET        /application-submitted           controllers.ApplicationSubmittedController.get(email, subscriptionId)
+GET        /application-submitted           controllers.ApplicationSubmittedController.get
 GET        /application-pending             controllers.ApplicationSubmittedController.pending
 GET        /application-successful          controllers.ApplicationSubmittedController.successful
 GET        /application-unsuccessful        controllers.ApplicationSubmittedController.rejected

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -13,7 +13,7 @@ GET        /your-details                    controllers.YourDetailsController.ge
 POST       /your-details                    controllers.YourDetailsController.post
 GET        /check-your-answers              controllers.SummaryController.get
 GET        /submit-registration             controllers.RosmController.get
-GET        /application-submitted           controllers.ApplicationSubmittedController.get(email)
+GET        /application-submitted           controllers.ApplicationSubmittedController.get(email, subscriptionId)
 GET        /application-pending             controllers.ApplicationSubmittedController.pending
 GET        /application-successful          controllers.ApplicationSubmittedController.successful
 GET        /application-unsuccessful        controllers.ApplicationSubmittedController.rejected

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -87,6 +87,11 @@ microservice {
           port = 9272
           domain = save4later
         }
+        session-cache {
+          host = localhost
+          port = 8400
+          domain = keystore
+        }
       }
     }
 }

--- a/test/connectors/TaxEnrolmentConnectorSpec.scala
+++ b/test/connectors/TaxEnrolmentConnectorSpec.scala
@@ -60,9 +60,9 @@ class TaxEnrolmentConnectorSpec extends PlaySpec
     lastModified = new DateTime(),
     credId = "",
     serviceName = "HMRC-LISA-ORG",
-    identifiers = Nil,
+    identifiers = List(TaxEnrolmentIdentifier("ZREF", "Z1234")),
     callback = "",
-    state = TaxEnrolmentSuccess,
+    state = TaxEnrolmentSuccess("Z1234"),
     etmpId = "",
     groupIdentifier = ""
   )

--- a/test/connectors/TaxEnrolmentJsonFormatsSpec.scala
+++ b/test/connectors/TaxEnrolmentJsonFormatsSpec.scala
@@ -53,7 +53,7 @@ class TaxEnrolmentJsonFormatsSpec extends PlaySpec with TaxEnrolmentJsonFormats 
 
         val sub = parsed.head
 
-        sub.state mustBe TaxEnrolmentSuccess
+        sub.state mustBe TaxEnrolmentSuccess("Z1234")
       }
       "given valid json with identifiers set to null" in {
         val parsed = Json.parse(testJsonNullIdentifiers).as[List[TaxEnrolmentSubscription]]
@@ -94,8 +94,8 @@ class TaxEnrolmentJsonFormatsSpec extends PlaySpec with TaxEnrolmentJsonFormats 
                            |    "serviceName": "HMRC-ORG-LISA",
                            |    "identifiers": [
                            |        {
-                           |            "key": "eori",
-                           |            "value": "gb123456ghj"
+                           |            "key": "ZREF",
+                           |            "value": "Z1234"
                            |        }
                            |    ],
                            |    "callback": "callback url",

--- a/test/controllers/ApplicationSubmittedControllerSpec.scala
+++ b/test/controllers/ApplicationSubmittedControllerSpec.scala
@@ -50,7 +50,7 @@ class ApplicationSubmittedControllerSpec extends PlaySpec
       when(mockAuthorisationService.userStatus(any())).
         thenReturn(Future.successful(UserAuthorised("id", UserDetails(None, None, ""), TaxEnrolmentPending)))
 
-      val result = SUT.get("test@user.com")(fakeRequest)
+      val result = SUT.get("test@user.com", "123456789")(fakeRequest)
 
       status(result) mustBe Status.OK
 
@@ -58,6 +58,7 @@ class ApplicationSubmittedControllerSpec extends PlaySpec
 
       content must include (submittedPageTitle)
       content must include ("test@user.com")
+      content must include ("123456789")
 
     }
 

--- a/test/controllers/ApplicationSubmittedControllerSpec.scala
+++ b/test/controllers/ApplicationSubmittedControllerSpec.scala
@@ -93,6 +93,9 @@ class ApplicationSubmittedControllerSpec extends PlaySpec
       when(mockAuthorisationService.userStatus(any())).
         thenReturn(Future.successful(UserAuthorised("id", UserDetails(None, None, ""), TaxEnrolmentDoesNotExist)))
 
+      when(mockSessionCache.fetchAndGetEntry[String](MatcherEquals("lisaManagerReferenceNumber"))(any(), any())).
+        thenReturn(Future.successful(Some("Z9999")))
+
       val result = SUT.successful()(fakeRequest)
 
       status(result) mustBe Status.OK
@@ -100,6 +103,7 @@ class ApplicationSubmittedControllerSpec extends PlaySpec
       val content = contentAsString(result)
 
       content must include (successPageTitle)
+      content must include ("Z9999")
       
     }
     

--- a/test/controllers/ApplicationSubmittedControllerSpec.scala
+++ b/test/controllers/ApplicationSubmittedControllerSpec.scala
@@ -19,8 +19,8 @@ package controllers
 import java.io.File
 
 import helpers.CSRFTest
-import models.{TaxEnrolmentDoesNotExist, TaxEnrolmentPending, UserAuthorised, UserDetails}
-import org.mockito.Matchers.{any, matches}
+import models._
+import org.mockito.Matchers.{eq => MatcherEquals, _}
 import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfter
 import org.scalatest.mockito.MockitoSugar
@@ -32,7 +32,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Configuration, Environment, Mode}
 import services.AuthorisationService
-import uk.gov.hmrc.http.cache.client.ShortLivedCache
+import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -50,7 +50,10 @@ class ApplicationSubmittedControllerSpec extends PlaySpec
       when(mockAuthorisationService.userStatus(any())).
         thenReturn(Future.successful(UserAuthorised("id", UserDetails(None, None, ""), TaxEnrolmentPending)))
 
-      val result = SUT.get("test@user.com", "123456789")(fakeRequest)
+      when(mockSessionCache.fetchAndGetEntry[ApplicationSent](MatcherEquals(ApplicationSent.cacheKey))(any(), any())).
+        thenReturn(Future.successful(Some(ApplicationSent(email = "test@user.com", subscriptionId = "123456789"))))
+
+      val result = SUT.get()(fakeRequest)
 
       status(result) mustBe Status.OK
 
@@ -132,12 +135,14 @@ class ApplicationSubmittedControllerSpec extends PlaySpec
   val mockConfig: Configuration = mock[Configuration]
   val mockEnvironment: Environment = Environment(mock[File], mock[ClassLoader], Mode.Test)
   val mockCache: ShortLivedCache = mock[ShortLivedCache]
+  val mockSessionCache: SessionCache = mock[SessionCache]
   val mockAuthorisationService: AuthorisationService = mock[AuthorisationService]
 
   object SUT extends ApplicationSubmittedController {
     override val config: Configuration = mockConfig
     override val env: Environment = mockEnvironment
-    override val cache: ShortLivedCache = mockCache
+    override val shortLivedCache: ShortLivedCache = mockCache
+    override val sessionCache: SessionCache = mockSessionCache
     override val authorisationService: AuthorisationService = mockAuthorisationService
   }
 

--- a/test/controllers/BusinessStructureControllerSpec.scala
+++ b/test/controllers/BusinessStructureControllerSpec.scala
@@ -33,7 +33,7 @@ import play.api.test.Helpers._
 import play.api.test.{FakeHeaders, FakeRequest}
 import play.api.{Configuration, Environment, Mode}
 import services.AuthorisationService
-import uk.gov.hmrc.http.cache.client.ShortLivedCache
+import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache}
 
 import scala.concurrent.Future
 
@@ -142,12 +142,14 @@ class BusinessStructureControllerSpec extends PlaySpec
   val mockConfig: Configuration = mock[Configuration]
   val mockEnvironment: Environment = Environment(mock[File], mock[ClassLoader], Mode.Test)
   val mockCache: ShortLivedCache = mock[ShortLivedCache]
+  val mockSessionCache: SessionCache = mock[SessionCache]
   val mockAuthorisationService: AuthorisationService = mock[AuthorisationService]
 
   object SUT extends BusinessStructureController {
     override val config: Configuration = mockConfig
     override val env: Environment = mockEnvironment
-    override val cache: ShortLivedCache = mockCache
+    override val shortLivedCache: ShortLivedCache = mockCache
+    override val sessionCache: SessionCache = mockSessionCache
     override val authorisationService: AuthorisationService = mockAuthorisationService
   }
 

--- a/test/controllers/LisaBaseControllerSpec.scala
+++ b/test/controllers/LisaBaseControllerSpec.scala
@@ -19,8 +19,9 @@ package controllers
 import java.io.File
 
 import models._
-import org.mockito.Matchers._
-import org.mockito.Mockito.when
+import org.mockito.Matchers.{eq => MatcherEquals, _}
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfter
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -36,9 +37,14 @@ import scala.concurrent.Future
 
 class LisaBaseControllerSpec extends PlaySpec
   with GuiceOneAppPerSuite
-  with MockitoSugar {
+  with MockitoSugar
+  with BeforeAndAfter {
 
   "Lisa Base Controller" should {
+
+    before {
+      reset(mockSessionCache)
+    }
 
     "redirect to login" when {
 
@@ -121,6 +127,8 @@ class LisaBaseControllerSpec extends PlaySpec
         val result = SUT.testAuthorisation(fakeRequest)
 
         redirectLocation(result) mustBe Some(routes.ApplicationSubmittedController.successful().url)
+
+        verify(mockSessionCache).cache(MatcherEquals("lisaManagerReferenceNumber"), MatcherEquals("Z1234"))(any(), any())
 
       }
 

--- a/test/controllers/LisaBaseControllerSpec.scala
+++ b/test/controllers/LisaBaseControllerSpec.scala
@@ -30,7 +30,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Configuration, Environment, Mode}
 import services.AuthorisationService
-import uk.gov.hmrc.http.cache.client.ShortLivedCache
+import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache}
 
 import scala.concurrent.Future
 
@@ -186,6 +186,7 @@ class LisaBaseControllerSpec extends PlaySpec
   val mockConfig: Configuration = mock[Configuration]
   val mockEnvironment: Environment = Environment(mock[File], mock[ClassLoader], Mode.Test)
   val mockCache: ShortLivedCache = mock[ShortLivedCache]
+  val mockSessionCache: SessionCache = mock[SessionCache]
   val mockAuthorisationService: AuthorisationService = mock[AuthorisationService]
 
   trait SUT extends LisaBaseController {
@@ -200,7 +201,8 @@ class LisaBaseControllerSpec extends PlaySpec
   object SUT extends SUT {
     override val config: Configuration = mockConfig
     override val env: Environment = mockEnvironment
-    override val cache: ShortLivedCache = mockCache
+    override val shortLivedCache: ShortLivedCache = mockCache
+    override val sessionCache: SessionCache = mockSessionCache
     override val authorisationService: AuthorisationService = mockAuthorisationService
   }
 

--- a/test/controllers/LisaBaseControllerSpec.scala
+++ b/test/controllers/LisaBaseControllerSpec.scala
@@ -116,7 +116,7 @@ class LisaBaseControllerSpec extends PlaySpec
 
       "an authorised user has a successful subscription" in {
         when(mockAuthorisationService.userStatus(any())).
-          thenReturn(Future.successful(UserAuthorised("", UserDetails(None, None, ""), TaxEnrolmentSuccess)))
+          thenReturn(Future.successful(UserAuthorised("", UserDetails(None, None, ""), TaxEnrolmentSuccess("Z1234"))))
 
         val result = SUT.testAuthorisation(fakeRequest)
 

--- a/test/controllers/OrganisationDetailsControllerSpec.scala
+++ b/test/controllers/OrganisationDetailsControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import java.io.File
 
 import helpers.CSRFTest
-import models.{BusinessStructure,OrganisationDetails, TaxEnrolmentDoesNotExist, UserAuthorised, UserDetails}
+import models.{BusinessStructure, OrganisationDetails, TaxEnrolmentDoesNotExist, UserAuthorised, UserDetails}
 import org.mockito.Matchers.{eq => matcherEq, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
@@ -32,8 +32,8 @@ import play.api.mvc.{AnyContentAsEmpty, AnyContentAsJson}
 import play.api.test.Helpers._
 import play.api.test.{FakeHeaders, FakeRequest}
 import play.api.{Configuration, Environment, Mode}
-import services.{RosmService,AuthorisationService}
-import uk.gov.hmrc.http.cache.client.ShortLivedCache
+import services.{AuthorisationService, RosmService}
+import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -242,13 +242,15 @@ class OrganisationDetailsControllerSpec extends PlaySpec
   val mockConfig: Configuration = mock[Configuration]
   val mockEnvironment: Environment = Environment(mock[File], mock[ClassLoader], Mode.Test)
   val mockCache: ShortLivedCache = mock[ShortLivedCache]
+  val mockSessionCache: SessionCache = mock[SessionCache]
   val mockAuthorisationService: AuthorisationService = mock[AuthorisationService]
   val mockRosmService:RosmService = mock[RosmService]
 
   object SUT extends OrganisationDetailsController {
     override val config: Configuration = mockConfig
     override val env: Environment = mockEnvironment
-    override val cache: ShortLivedCache = mockCache
+    override val shortLivedCache: ShortLivedCache = mockCache
+    override val sessionCache: SessionCache = mockSessionCache
     override val authorisationService: AuthorisationService = mockAuthorisationService
     override val rosmService:RosmService = mockRosmService
 

--- a/test/controllers/RosmControllerSpec.scala
+++ b/test/controllers/RosmControllerSpec.scala
@@ -33,7 +33,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Configuration, Environment, Mode}
 import services.{AuditService, AuthorisationService, RosmService}
-import uk.gov.hmrc.http.cache.client.ShortLivedCache
+import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -47,6 +47,7 @@ class RosmControllerSpec extends PlaySpec
   "GET Rosm Registration" must {
 
     before {
+      reset(mockSessionCache)
       reset(mockCache)
       reset(mockRosmConnector)
       reset(mockAuditService)
@@ -133,7 +134,6 @@ class RosmControllerSpec extends PlaySpec
       }
     }
 
-
     "redirect the user to your details" when {
       "no your details are found in the cache" in {
         val organisationForm = new OrganisationDetails("Test Company Name", "1234567890")
@@ -202,7 +202,7 @@ class RosmControllerSpec extends PlaySpec
         contactDetails = rosmContact
       )
 
-      redirectLocation(SUT.get(fakeRequest)) must be(Some(routes.ApplicationSubmittedController.get("test@test.com", "123456789").url))
+      redirectLocation(SUT.get(fakeRequest)) must be(Some(routes.ApplicationSubmittedController.get().url))
     }
 
     "handle a failed rosm registration" when {
@@ -354,6 +354,53 @@ class RosmControllerSpec extends PlaySpec
 
     }
 
+    "cache subscriptionId and email as part of a successful rosm registration" in {
+      val uri = controllers.routes.RosmController.get().url
+      val organisationForm = new OrganisationDetails("Test Company Name", "1234567890")
+      val tradingForm = new TradingDetails(fsrRefNumber = "123", isaProviderRefNumber = "123")
+      val businessStructureForm = new BusinessStructure("LLP")
+      val yourForm = new YourDetails(
+        firstName = "Test",
+        lastName = "User",
+        role = "Role",
+        phone = "0191 123 4567",
+        email = "test@test.com")
+      val registrationDetails = LisaRegistration(organisationForm, tradingForm, businessStructureForm, yourForm, "123456")
+
+      when(mockCache.fetchAndGetEntry[OrganisationDetails](any(), org.mockito.Matchers.eq(organisationDetailsCacheKey))(any(), any())).
+        thenReturn(Future.successful(Some(organisationForm)))
+
+      when(mockCache.fetchAndGetEntry[String](any(), org.mockito.Matchers.eq("safeId"))(any(), any())).
+        thenReturn(Future.successful(Some("123456")))
+
+      when(mockCache.fetchAndGetEntry[TradingDetails](any(), org.mockito.Matchers.eq(tradingDetailsCacheKey))(any(), any())).
+        thenReturn(Future.successful(Some(tradingForm)))
+
+      when(mockCache.fetchAndGetEntry[BusinessStructure](any(), org.mockito.Matchers.eq(businessStructureCacheKey))(any(), any())).
+        thenReturn(Future.successful(Some(businessStructureForm)))
+
+      when(mockCache.fetchAndGetEntry[YourDetails](any(), org.mockito.Matchers.eq(yourDetailsCacheKey))(any(), any())).
+        thenReturn(Future.successful(Some(yourForm)))
+
+      val rosmAddress = RosmAddress(addressLine1 = "", countryCode = "")
+      val rosmContact = RosmContactDetails()
+      val rosmSuccessResponse = RosmRegistrationSuccessResponse(
+        safeId = "",
+        isEditable = true,
+        isAnAgent = true,
+        isAnIndividual = true,
+        address = rosmAddress,
+        contactDetails = rosmContact
+      )
+      when (mockRosmService.performSubscription(any())(any())).thenReturn(Future.successful(Right("123456789012")))
+
+      await(SUT.get(fakeRequest))
+
+      val applicationSentVM = ApplicationSent(subscriptionId = "123456789012", email = registrationDetails.yourDetails.email)
+
+      verify(mockSessionCache).cache(MatcherEquals(ApplicationSent.cacheKey), MatcherEquals(applicationSentVM))(any(), any())
+    }
+
   }
 
   implicit val hc:HeaderCarrier = HeaderCarrier()
@@ -363,6 +410,7 @@ class RosmControllerSpec extends PlaySpec
   val mockRosmConnector: RosmConnector = mock[RosmConnector]
   val mockConfig: Configuration = mock[Configuration]
   val mockEnvironment: Environment = Environment(mock[File], mock[ClassLoader], Mode.Test)
+  val mockSessionCache: SessionCache = mock[SessionCache]
   val mockCache: ShortLivedCache = mock[ShortLivedCache]
   val mockAuditService: AuditService = mock[AuditService]
   val mockRosmService: RosmService = mock[RosmService]
@@ -371,7 +419,8 @@ class RosmControllerSpec extends PlaySpec
   object SUT extends RosmController {
     override val config: Configuration = mockConfig
     override val env: Environment = mockEnvironment
-    override val cache: ShortLivedCache = mockCache
+    override val sessionCache: SessionCache = mockSessionCache
+    override val shortLivedCache: ShortLivedCache = mockCache
     override val auditService: AuditService = mockAuditService
     override val rosmService: RosmService = mockRosmService
     override val authorisationService: AuthorisationService = mockAuthorisationService

--- a/test/controllers/RosmControllerSpec.scala
+++ b/test/controllers/RosmControllerSpec.scala
@@ -202,7 +202,7 @@ class RosmControllerSpec extends PlaySpec
         contactDetails = rosmContact
       )
 
-      redirectLocation(SUT.get(fakeRequest)) must be(Some(routes.ApplicationSubmittedController.get("test@test.com").url))
+      redirectLocation(SUT.get(fakeRequest)) must be(Some(routes.ApplicationSubmittedController.get("test@test.com", "123456789").url))
     }
 
     "handle a failed rosm registration" when {

--- a/test/controllers/SummaryControllerSpec.scala
+++ b/test/controllers/SummaryControllerSpec.scala
@@ -32,7 +32,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Configuration, Environment, Mode}
 import services.AuthorisationService
-import uk.gov.hmrc.http.cache.client.ShortLivedCache
+import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -213,12 +213,14 @@ class SummaryControllerSpec extends PlaySpec
   val mockConfig: Configuration = mock[Configuration]
   val mockEnvironment: Environment = Environment(mock[File], mock[ClassLoader], Mode.Test)
   val mockCache: ShortLivedCache = mock[ShortLivedCache]
+  val mockSessionCache: SessionCache = mock[SessionCache]
   val mockAuthorisationService: AuthorisationService = mock[AuthorisationService]
 
   object SUT extends SummaryController {
     override val config: Configuration = mockConfig
     override val env: Environment = mockEnvironment
-    override val cache: ShortLivedCache = mockCache
+    override val shortLivedCache: ShortLivedCache = mockCache
+    override val sessionCache: SessionCache = mockSessionCache
     override val authorisationService: AuthorisationService = mockAuthorisationService
   }
 

--- a/test/controllers/TradingDetailsControllerSpec.scala
+++ b/test/controllers/TradingDetailsControllerSpec.scala
@@ -33,7 +33,7 @@ import play.api.test.Helpers._
 import play.api.test.{FakeHeaders, FakeRequest}
 import play.api.{Configuration, Environment, Mode}
 import services.AuthorisationService
-import uk.gov.hmrc.http.cache.client.ShortLivedCache
+import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -152,12 +152,14 @@ class TradingDetailsControllerSpec extends PlaySpec
   val mockConfig: Configuration = mock[Configuration]
   val mockEnvironment: Environment = Environment(mock[File], mock[ClassLoader], Mode.Test)
   val mockCache: ShortLivedCache = mock[ShortLivedCache]
+  val mockSessionCache: SessionCache = mock[SessionCache]
   val mockAuthorisationService: AuthorisationService = mock[AuthorisationService]
 
   object SUT extends TradingDetailsController {
     override val config: Configuration = mockConfig
     override val env: Environment = mockEnvironment
-    override val cache: ShortLivedCache = mockCache
+    override val shortLivedCache: ShortLivedCache = mockCache
+    override val sessionCache: SessionCache = mockSessionCache
     override val authorisationService: AuthorisationService = mockAuthorisationService
   }
 

--- a/test/controllers/YourDetailsControllerSpec.scala
+++ b/test/controllers/YourDetailsControllerSpec.scala
@@ -33,7 +33,7 @@ import play.api.test.Helpers._
 import play.api.test.{FakeHeaders, FakeRequest}
 import play.api.{Configuration, Environment, Mode}
 import services.AuthorisationService
-import uk.gov.hmrc.http.cache.client.ShortLivedCache
+import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache}
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -162,12 +162,14 @@ class YourDetailsControllerSpec extends PlaySpec
   val mockConfig: Configuration = mock[Configuration]
   val mockEnvironment: Environment = Environment(mock[File], mock[ClassLoader], Mode.Test)
   val mockCache: ShortLivedCache = mock[ShortLivedCache]
+  val mockSessionCache: SessionCache = mock[SessionCache]
   val mockAuthorisationService: AuthorisationService = mock[AuthorisationService]
 
   object SUT extends YourDetailsController {
     override val config: Configuration = mockConfig
     override val env: Environment = mockEnvironment
-    override val cache: ShortLivedCache = mockCache
+    override val shortLivedCache: ShortLivedCache = mockCache
+    override val sessionCache: SessionCache = mockSessionCache
     override val authorisationService: AuthorisationService = mockAuthorisationService
   }
 

--- a/test/services/AuthorisationServiceSpec.scala
+++ b/test/services/AuthorisationServiceSpec.scala
@@ -147,6 +147,6 @@ class AuthorisationServiceSpec extends PlaySpec
 
   val successfulRetrieval: Future[~[Option[String], Option[String]]] = Future.successful(new ~(Some("1234"), Some("/")))
 
-  when(mockTaxEnrolmentService.getLisaSubscriptionState(any())(any())).thenReturn(Future.successful(TaxEnrolmentDoesNotExist))
+  when(mockTaxEnrolmentService.getNewestLisaSubscription(any())(any())).thenReturn(Future.successful(None))
 
 }

--- a/test/services/TaxEnrolmentServiceSpec.scala
+++ b/test/services/TaxEnrolmentServiceSpec.scala
@@ -94,6 +94,19 @@ class TaxEnrolmentServiceSpec extends PlaySpec with MockitoSugar with OneAppPerS
 
     }
 
+    "throw an error" when {
+
+      "a successful subscription does not contain a zref" in {
+        when(mockConnector.getSubscriptionsByGroupId(any())(any())).thenReturn(
+          Future.successful(List(lisaSuccessSubscription.copy(identifiers = Nil, state = TaxEnrolmentSuccess))))
+
+        assertThrows[RuntimeException] {
+          Await.result(SUT.getNewestLisaSubscription("1234567890"), Duration.Inf)
+        }
+      }
+
+    }
+
   }
 
   private val lisaSuccessSubscription = TaxEnrolmentSubscription(

--- a/test/services/TaxEnrolmentServiceSpec.scala
+++ b/test/services/TaxEnrolmentServiceSpec.scala
@@ -101,9 +101,9 @@ class TaxEnrolmentServiceSpec extends PlaySpec with MockitoSugar with OneAppPerS
     lastModified = new DateTime(),
     credId = "",
     serviceName = "HMRC-LISA-ORG",
-    identifiers = Nil,
+    identifiers = List(TaxEnrolmentIdentifier("ZREF", "Z1234")),
     callback = "",
-    state = TaxEnrolmentSuccess,
+    state = TaxEnrolmentSuccess("Z1234"),
     etmpId = "",
     groupIdentifier = ""
   )

--- a/test/services/TaxEnrolmentServiceSpec.scala
+++ b/test/services/TaxEnrolmentServiceSpec.scala
@@ -47,36 +47,36 @@ class TaxEnrolmentServiceSpec extends PlaySpec with MockitoSugar with OneAppPerS
         when(mockConnector.getSubscriptionsByGroupId(any())(any())).thenReturn(
           Future.successful(List(lisaSuccessSubscription)))
 
-        val res = Await.result(SUT.getLisaSubscriptionState("1234567890"), Duration.Inf)
+        val res = Await.result(SUT.getNewestLisaSubscription("1234567890"), Duration.Inf)
 
-        res mustBe TaxEnrolmentSuccess
+        res mustBe Some(lisaSuccessSubscription)
       }
 
       "given two lisa subscriptions in the connector response - newest first" in {
         when(mockConnector.getSubscriptionsByGroupId(any())(any())).thenReturn(
           Future.successful(List(lisaErrorSubscription, lisaSuccessSubscription)))
 
-        val res = Await.result(SUT.getLisaSubscriptionState("1234567890"), Duration.Inf)
+        val res = Await.result(SUT.getNewestLisaSubscription("1234567890"), Duration.Inf)
 
-        res mustBe TaxEnrolmentError
+        res mustBe Some(lisaErrorSubscription)
       }
 
       "given two lisa subscriptions in the connector response - oldest first" in {
         when(mockConnector.getSubscriptionsByGroupId(any())(any())).thenReturn(
           Future.successful(List(lisaSuccessSubscription, lisaErrorSubscription)))
 
-        val res = Await.result(SUT.getLisaSubscriptionState("1234567890"), Duration.Inf)
+        val res = Await.result(SUT.getNewestLisaSubscription("1234567890"), Duration.Inf)
 
-        res mustBe TaxEnrolmentError
+        res mustBe Some(lisaErrorSubscription)
       }
 
       "given multiple different subscriptions in the connector response" in {
         when(mockConnector.getSubscriptionsByGroupId(any())(any())).thenReturn(
           Future.successful(List(lisaSuccessSubscription, lisaErrorSubscription, randomPendingSubscription)))
 
-        val res = Await.result(SUT.getLisaSubscriptionState("1234567890"), Duration.Inf)
+        val res = Await.result(SUT.getNewestLisaSubscription("1234567890"), Duration.Inf)
 
-        res mustBe TaxEnrolmentError
+        res mustBe Some(lisaErrorSubscription)
       }
 
     }
@@ -87,9 +87,9 @@ class TaxEnrolmentServiceSpec extends PlaySpec with MockitoSugar with OneAppPerS
         when(mockConnector.getSubscriptionsByGroupId(any())(any())).thenReturn(
           Future.successful(List()))
 
-        val res = Await.result(SUT.getLisaSubscriptionState("1234567890"), Duration.Inf)
+        val res = Await.result(SUT.getNewestLisaSubscription("1234567890"), Duration.Inf)
 
-        res mustBe TaxEnrolmentDoesNotExist
+        res mustBe None
       }
 
     }


### PR DESCRIPTION
Application sent
* subscriptionId and email are now passed in via session cache rather than url

Application successful
* zref number now stored in and retrieved from session cache