### PR TITLE
IE Edge fix for check your answers page

### DIFF
--- a/app/assets/stylesheets/partials/_tabular-data.scss
+++ b/app/assets/stylesheets/partials/_tabular-data.scss
@@ -20,6 +20,7 @@
 
   .tabular-data__data-1 {
     overflow-wrap: break-word;
+    word-wrap: break-word;
     @media (min-width: $tablet-breakpoint){
       box-sizing: border-box;
       padding-left: 2%;


### PR DESCRIPTION
The users answers werent wrapping correctly when the exceeded the length of the available space for them.

This was down to IE Edge < 18 not supporting overflow-wrap. Added in word-wrap which does the exact same thing.