### PR TITLE
Fixed a couple of race conditions

### DIFF
--- a/app/controllers/LisaBaseController.scala
+++ b/app/controllers/LisaBaseController.scala
@@ -89,9 +89,9 @@ trait LisaBaseController extends FrontendController
     Logger.warn("User Authorised And Enrolled")
 
     if (checkEnrolmentState) {
-      sessionCache.cache[String]("lisaManagerReferenceNumber", user.lisaManagerReferenceNumber)
-
-      Future.successful(Redirect(routes.ApplicationSubmittedController.successful()))
+      sessionCache.cache[String]("lisaManagerReferenceNumber", user.lisaManagerReferenceNumber).map { _ =>
+        Redirect(routes.ApplicationSubmittedController.successful())
+      }
     }
     else {
       callback(s"${user.internalId}-lisa-registration")

--- a/app/controllers/OrganisationDetailsController.scala
+++ b/app/controllers/OrganisationDetailsController.scala
@@ -86,8 +86,9 @@ class OrganisationDetailsController @Inject()(
                 rosmService.rosmRegister(businessStructure, data).flatMap {
                   case Right(safeId) => {
                     Logger.debug("rosmRegister Successful")
-                    shortLivedCache.cache[String](cacheId, "safeId", safeId)
-                    handleRedirect(routes.TradingDetailsController.get().url)
+                    shortLivedCache.cache[String](cacheId, "safeId", safeId).flatMap { _ =>
+                      handleRedirect(routes.TradingDetailsController.get().url)
+                    }
                   }
                   case Left(error) => {
                     Logger.error(s"OrganisationDetailsController: rosmRegister Failure due to $error")

--- a/app/controllers/TradingDetailsController.scala
+++ b/app/controllers/TradingDetailsController.scala
@@ -39,12 +39,10 @@ class TradingDetailsController @Inject()(
 
   val get: Action[AnyContent] = Action.async { implicit request =>
     authorisedForLisa { (cacheId) =>
-
       shortLivedCache.fetchAndGetEntry[TradingDetails](cacheId, TradingDetails.cacheKey).map {
         case Some(data) => Ok(views.html.registration.trading_details(TradingDetails.form.fill(data)))
         case None => Ok(views.html.registration.trading_details(TradingDetails.form))
       }
-
     }
   }
 
@@ -60,7 +58,6 @@ class TradingDetailsController @Inject()(
           }
         }
       )
-
     }
   }
 


### PR DESCRIPTION
In "handleUserAuthorisedAndEnrolled" in the base controller, we cache some
data then redirect the user to a page which depends on that data being
present in the cache.

As caching is async, we were vulnerable to the redirection being processed
before the caching had completed - therefore getting an error when the
new page tries to retrieve data which hasn't yet been cached.

The code has now been updated such that the redirection only occurs once
the caching has completed, removing this race condition.

Edit: found a similar problem with the caching of the safeId. Fixed this also.