### PR TITLE
LISA-2356: Made gg callback urls absolute

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -172,7 +172,7 @@ ca-frontend {
 play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com www.googletagmanager.com fonts.googleapis.com tagmanager.google.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com data:"
 
 gg-urls {
-  login-callback.url = "/lifetime-isa/company-structure"
+  login-callback.url = "http://localhost:8884/lifetime-isa/company-structure"
   logout-callback.url = "http://localhost:8884/lifetime-isa/signed-out"
   registerOrg.url = "https://myaccount.gateway.gov.uk/RegisterOrLogon.aspx?gwcategory=org&gwv=1.0&gwrealm=http://www.gateway.gov.uk/myaccount/2007/07&gwlang=en-GB&gwreply=http://www.gateway.gov.uk/Default.aspx"
 }


### PR DESCRIPTION
Needed to ensure the correct port numbers are passed across.

Overwritten in app-config-base with relative urls.