### PR TITLE
[DDCE-646] remove warning from check-your-answers page

### DIFF
--- a/app/views/registration/summary.scala.html
+++ b/app/views/registration/summary.scala.html
@@ -149,17 +149,6 @@
         </dl>
     </section>
 
-    <div class="subsection">
-        <div class="notice">
-            <i class="icon icon-important">
-                <span class="visually-hidden">Legal notice</span>
-            </i>
-            <strong class="bold-small">
-                By applying, you confirm the details you have provided are correct.
-            </strong>
-        </div>
-    </div>
-
     <form method="post" action="@routes.RosmController.post">
         @CSRF.formField
         <div class="form-field form-field--submit">


### PR DESCRIPTION
# DDCE-646

##Maintenance - accessibility review action

The warning subsection on the "/check-your-answers page" was removed.

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
(removing static html ... no unit tests / ATs linked to this)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date 
(small ticket and has been done recently - will do next time)

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
