### PR TITLE
Play 2.7 and bootstrap-frontend-27 migration

### DIFF
--- a/app/config/frontendGlobal.scala
+++ b/app/config/frontendGlobal.scala
@@ -24,8 +24,9 @@ import play.api.{Configuration, Environment}
 import play.twirl.api.{Html, HtmlFormat}
 import uk.gov.hmrc.crypto.{ApplicationCrypto, CryptoWithKeysFromConfig}
 import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache, ShortLivedHttpCaching}
-import uk.gov.hmrc.play.bootstrap.http.{FrontendErrorHandler, HttpClient}
-import uk.gov.hmrc.play.bootstrap.config.{RunMode, ServicesConfig}
+import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.Future
 
@@ -55,8 +56,7 @@ class ErrorHandler @Inject()(val messagesApi: MessagesApi,
 class LisaSessionCache @Inject()(
   val http: HttpClient,
   val runModeConfiguration: Configuration,
-  runMode: RunMode,
-  environment: Environment) extends ServicesConfig(runModeConfiguration: Configuration, runMode: RunMode) with SessionCache {
+  environment: Environment) extends ServicesConfig(runModeConfiguration: Configuration) with SessionCache {
 
   override lazy val defaultSource: String = getString("appName")
 
@@ -68,8 +68,7 @@ class LisaSessionCache @Inject()(
 class LisaShortLivedHttpCaching @Inject()(
   val http: HttpClient,
   val runModeConfiguration: Configuration,
-  runMode: RunMode,
-  environment: Environment) extends ServicesConfig(runModeConfiguration: Configuration, runMode: RunMode) with ShortLivedHttpCaching {
+  environment: Environment) extends ServicesConfig(runModeConfiguration: Configuration) with ShortLivedHttpCaching {
 
   override lazy val defaultSource: String = getString("appName")
 

--- a/app/connectors/EmailConnector.scala
+++ b/app/connectors/EmailConnector.scala
@@ -20,11 +20,11 @@ import com.google.inject.Inject
 import config.AppConfig
 import metrics.EmailMetrics
 import models.SendEmailRequest
-import play.api.Logger
+import play.api.Logging
 import play.api.http.Status._
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -38,7 +38,7 @@ class EmailConnector @Inject()(
   val http: HttpClient,
   appConfig: AppConfig,
   metrics: EmailMetrics
-) extends RawResponseReads {
+) extends RawResponseReads with Logging {
 
   def sendTemplatedEmail(emailAddress: String, templateName: String, params: Map[String, String])(implicit hc: HeaderCarrier): Future[EmailStatus] = {
 
@@ -50,12 +50,12 @@ class EmailConnector @Inject()(
     http.POST(postUrl, jsonData).map { response =>
       response.status match {
         case ACCEPTED => {
-          Logger.info("Email sent successfully.")
+          logger.info("Email sent successfully.")
           metrics.emailSentCounter()
           EmailSent
         }
         case status => {
-          Logger.warn("Email not sent.")
+          logger.warn("Email not sent.")
           metrics.emailNotSentCounter()
           EmailNotSent
         }

--- a/app/connectors/RawResponseReads.scala
+++ b/app/connectors/RawResponseReads.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.http.{ HttpReads, HttpResponse }
 trait RawResponseReads {
 
   implicit val httpReads: HttpReads[HttpResponse] = new HttpReads[HttpResponse] {
-    override def read(method: String, url: String, response: HttpResponse) = response
+    override def read(method: String, url: String, response: HttpResponse): HttpResponse = response
   }
 
 }

--- a/app/connectors/RosmConnector.scala
+++ b/app/connectors/RosmConnector.scala
@@ -28,11 +28,7 @@ import scala.concurrent.Future
 class RosmConnector @Inject()(
   val httpPost: HttpClient,
   val appConfig: AppConfig
-) extends RosmJsonFormats {
-
-  val httpReads:HttpReads[HttpResponse] = new HttpReads[HttpResponse] {
-    override def read(method: String, url: String, response: HttpResponse): HttpResponse = response
-  }
+) extends RosmJsonFormats with RawResponseReads {
 
   def registerOnce(utr: String, request:RosmRegistration)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     val uri = s"${appConfig.lisaServiceUrl}/lisa/$utr/register"

--- a/app/connectors/RosmConnector.scala
+++ b/app/connectors/RosmConnector.scala
@@ -20,7 +20,7 @@ import com.google.inject.Inject
 import config.AppConfig
 import models._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
-import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/app/connectors/TaxEnrolmentConnector.scala
+++ b/app/connectors/TaxEnrolmentConnector.scala
@@ -19,10 +19,9 @@ package connectors
 import com.google.inject.Inject
 import config.AppConfig
 import models._
-import play.api.Logger
+import play.api.Logging
 import play.api.libs.json.Json
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -30,13 +29,13 @@ import scala.concurrent.Future
 class TaxEnrolmentConnector @Inject()(
   val httpGet: HttpClient,
   val appConfig: AppConfig
-) extends TaxEnrolmentJsonFormats {
+) extends TaxEnrolmentJsonFormats with Logging {
 
   def getSubscriptionsByGroupId(groupId: String)(implicit hc: HeaderCarrier): Future[List[TaxEnrolmentSubscription]] = {
     val uri = s"${appConfig.lisaServiceUrl}/lisa/tax-enrolments/groups/$groupId/subscriptions"
 
     httpGet.GET[HttpResponse](uri)(implicitly, hc, implicitly) map { res =>
-      Logger.debug(s"Getsubscriptions returned status: ${res.status} ")
+      logger.debug(s"Getsubscriptions returned status: ${res.status} ")
       Json.parse(res.body).as[List[TaxEnrolmentSubscription]]
     }
   }

--- a/app/connectors/TaxEnrolmentConnector.scala
+++ b/app/connectors/TaxEnrolmentConnector.scala
@@ -29,12 +29,12 @@ import scala.concurrent.Future
 class TaxEnrolmentConnector @Inject()(
   val httpGet: HttpClient,
   val appConfig: AppConfig
-) extends TaxEnrolmentJsonFormats with Logging {
+) extends TaxEnrolmentJsonFormats with Logging with RawResponseReads {
 
   def getSubscriptionsByGroupId(groupId: String)(implicit hc: HeaderCarrier): Future[List[TaxEnrolmentSubscription]] = {
     val uri = s"${appConfig.lisaServiceUrl}/lisa/tax-enrolments/groups/$groupId/subscriptions"
 
-    httpGet.GET[HttpResponse](uri)(implicitly, hc, implicitly) map { res =>
+    httpGet.GET[HttpResponse](uri)(httpReads, hc, implicitly) map { res =>
       logger.debug(s"Getsubscriptions returned status: ${res.status} ")
       Json.parse(res.body).as[List[TaxEnrolmentSubscription]]
     }

--- a/app/controllers/ErrorController.scala
+++ b/app/controllers/ErrorController.scala
@@ -22,7 +22,7 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.play.bootstrap.config.AuthRedirects
-import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/models/BusinessStructure.scala
+++ b/app/models/BusinessStructure.scala
@@ -27,7 +27,7 @@ object BusinessStructure {
 
   val cacheKey = "businessStructure"
 
-  val form = Form(
+  val form: Form[BusinessStructure] = Form(
     mapping(
       "companyStructure" -> optional(text).verifying("error.companyStructureRequired", i => i.isDefined)
     )(bs => BusinessStructure(bs.get))(bs => Some(Some(bs.businessStructure)))

--- a/app/models/OrganisationDetails.scala
+++ b/app/models/OrganisationDetails.scala
@@ -30,7 +30,7 @@ object OrganisationDetails {
 
   implicit val formats: OFormat[OrganisationDetails] = Json.format[OrganisationDetails]
 
-  val form = Form(
+  val form: Form[OrganisationDetails] = Form(
     mapping(
       "companyName" -> optional(text)
         .verifying("error.companyNameRequired", _.isDefined)
@@ -50,7 +50,7 @@ object OrganisationDetails {
     )
   )
 
-  val partnershipForm = Form(
+  val partnershipForm: Form[OrganisationDetails] = Form(
     mapping(
       "companyName" -> optional(text)
         .verifying("error.companyNameRequired", _.isDefined)

--- a/app/models/Questionnaire.scala
+++ b/app/models/Questionnaire.scala
@@ -29,7 +29,7 @@ case class Questionnaire(
 object Questionnaire {
   val maxOptionSize = 4
   val maxBooleanOptionSize = 2
-  val form = Form(mapping(
+  val form: Form[Questionnaire] = Form(mapping(
     "easyToUse" -> optional(number(0, maxOptionSize)),
     "satisfactionLevel" -> optional(number(0, maxOptionSize)),
     "whyGiveThisRating" -> optional(text),

--- a/app/models/TradingDetails.scala
+++ b/app/models/TradingDetails.scala
@@ -29,7 +29,7 @@ object TradingDetails {
 
   implicit val formats: OFormat[TradingDetails] = Json.format[TradingDetails]
 
-  val form = Form(
+  val form: Form[TradingDetails] = Form(
     mapping(
       "fsrRefNumber" -> optional(text)
         .verifying("error.fsrRefNumberRequired", fsr => fsrExists(fsr))

--- a/app/models/YourDetails.scala
+++ b/app/models/YourDetails.scala
@@ -31,7 +31,7 @@ object YourDetails {
 
   val cacheKey = "yourDetails"
 
-  val form = Form(
+  val form: Form[YourDetails] = Form(
     mapping(
       "firstName" -> optional(text)
         .verifying("error.firstNameRequired", _.isDefined)

--- a/app/services/AuditService.scala
+++ b/app/services/AuditService.scala
@@ -18,7 +18,7 @@ package services
 
 import com.google.inject.Inject
 import config.AppConfig
-import play.api.Logger
+import play.api.Logging
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions._
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
@@ -27,7 +27,7 @@ import uk.gov.hmrc.play.audit.model.DataEvent
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class AuditService @Inject()(val connector: AuditConnector, val appConfig: AppConfig) {
+class AuditService @Inject()(val connector: AuditConnector, val appConfig: AppConfig) extends Logging {
 
   def audit(auditType: String, path: String, auditData: Map[String, String])(implicit hc:HeaderCarrier): Future[AuditResult] = {
     val event = DataEvent(
@@ -36,7 +36,7 @@ class AuditService @Inject()(val connector: AuditConnector, val appConfig: AppCo
       tags = hc.toAuditTags(auditType, path),
       detail = hc.toAuditDetails() ++ auditData
     )
-    Logger.info(s"audit Config ${connector.auditingConfig}")
+    logger.info(s"audit Config ${connector.auditingConfig}")
     connector.sendEvent(event)
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -32,7 +32,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
 
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.FrontendModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,19 +22,20 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "2.3.0",
-    "uk.gov.hmrc" %% "govuk-template" % "5.65.0-play-26",
-    "uk.gov.hmrc" %% "play-partials" % "7.1.0-play-26",
-    "uk.gov.hmrc" %% "auth-client" % "3.3.0-play-26",
-    "uk.gov.hmrc" %% "http-caching-client" % "9.2.0-play-26",
-    "uk.gov.hmrc" %% "play-frontend-hmrc" % "0.48.0-play-26"
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-27" % "4.2.0",
+    "uk.gov.hmrc" %% "govuk-template" % "5.65.0-play-27",
+    "uk.gov.hmrc" %% "play-partials" % "7.1.0-play-27",
+    "uk.gov.hmrc" %% "auth-client" % "3.3.0-play-27",
+    "uk.gov.hmrc" %% "http-caching-client" % "9.2.0-play-27",
+    "uk.gov.hmrc" %% "play-frontend-hmrc" % "0.48.0-play-27"
   )
 
   val test: Seq[ModuleID] = Seq(
     "org.pegdown" % "pegdown" % "1.6.0",
     "com.typesafe.play" %% "play-test" % PlayVersion.current,
     "org.mockito" % "mockito-core" % "3.8.0",
-    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3"
+    "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3",
+    "org.scalatestplus" %% "mockito-3-4" % "3.2.7.0"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -24,9 +24,9 @@ object AppDependencies {
     ws,
     "uk.gov.hmrc" %% "bootstrap-frontend-play-27" % "4.2.0",
     "uk.gov.hmrc" %% "govuk-template" % "5.65.0-play-27",
-    "uk.gov.hmrc" %% "play-partials" % "7.1.0-play-27",
+    "uk.gov.hmrc" %% "play-partials" % "8.0.0-play-27",
     "uk.gov.hmrc" %% "auth-client" % "3.3.0-play-27",
-    "uk.gov.hmrc" %% "http-caching-client" % "9.2.0-play-27",
+    "uk.gov.hmrc" %% "http-caching-client" % "9.3.0-play-27",
     "uk.gov.hmrc" %% "play-frontend-hmrc" % "0.48.0-play-27"
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.13.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 

--- a/test/connectors/EmailConnectorSpec.scala
+++ b/test/connectors/EmailConnectorSpec.scala
@@ -26,7 +26,7 @@ import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.JsValue
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.Future
 

--- a/test/connectors/RosmConnectorSpec.scala
+++ b/test/connectors/RosmConnectorSpec.scala
@@ -27,7 +27,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}

--- a/test/connectors/TaxEnrolmentConnectorSpec.scala
+++ b/test/connectors/TaxEnrolmentConnectorSpec.scala
@@ -27,7 +27,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json._
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
@@ -58,7 +58,8 @@ class TaxEnrolmentConnectorSpec extends PlaySpec
 
   "Get Subscriptions by Group ID endpoint" must {
     "return whatever it receives" in {
-      when(mockHttp.GET[HttpResponse](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
+      when(mockHttp.GET[HttpResponse](ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())
+        (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(HttpResponse(
           status = OK,
           json = Json.toJson(subs),


### PR DESCRIPTION
# DDCE-1652

- Moved over to bootstrap-frontend-27 which now includes the use of `hmrc.http.HttpClient`
- Upgraded dependencies to use Play 2.7
- Cleaned imports and handled depreciated assets

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
