### PR TITLE
DDCE-4741: Fix redirect to summary view

### DIFF
--- a/app/controllers/BusinessStructureController.scala
+++ b/app/controllers/BusinessStructureController.scala
@@ -43,8 +43,8 @@ class BusinessStructureController @Inject()(
   val get: Action[AnyContent] = Action.async { implicit request =>
     authorisedForLisa { cacheId: String =>
       sessionCacheRepository.getFromSession[BusinessStructure](DataKey(BusinessStructure.cacheKey)).map {
-        case Some(data) => Ok(businessStructureView(BusinessStructure.form.fill(data)))
-        case None => Ok(businessStructureView(BusinessStructure.form))
+        case Some(data) => Ok(businessStructureView(createPostCall, BusinessStructure.form.fill(data)))
+        case None => Ok(businessStructureView(createPostCall, BusinessStructure.form))
       }
     }
   }
@@ -53,7 +53,7 @@ class BusinessStructureController @Inject()(
     authorisedForLisa { cacheId =>
       BusinessStructure.form.bindFromRequest().fold(
         formWithErrors => {
-          Future.successful(BadRequest(businessStructureView(formWithErrors)))
+          Future.successful(BadRequest(businessStructureView(createPostCall, formWithErrors)))
         },
         (data: BusinessStructure) => {
           sessionCacheRepository.putSession[BusinessStructure](DataKey(BusinessStructure.cacheKey), data).flatMap { _ =>

--- a/app/controllers/LisaBaseController.scala
+++ b/app/controllers/LisaBaseController.scala
@@ -122,6 +122,10 @@ abstract class LisaBaseController(messagesControllerComponents: MessagesControll
     cache.get(key).map(_.as[T]).toRight(redirect)
   }
 
+  def createPostCall(implicit request: MessagesRequest[AnyContent]): Call = {
+    Call("POST", request.uri)
+  }
+
   def handleRedirect(redirectUrl: String)(implicit request: Request[AnyContent]): Future[Result] = {
     val returnUrl: Option[String] = request.getQueryString("returnUrl")
 

--- a/app/controllers/OrganisationDetailsController.scala
+++ b/app/controllers/OrganisationDetailsController.scala
@@ -56,11 +56,13 @@ class OrganisationDetailsController @Inject()(
           sessionCacheRepository.getFromSession[OrganisationDetails](DataKey(OrganisationDetails.cacheKey)).map {
             case Some(data) =>
               Ok(organisationDetailsView(
+                createPostCall,
                 orgDetailsForm.fill(data),
                 isPartnership
               ))
             case None =>
               Ok(organisationDetailsView(
+                createPostCall,
                 orgDetailsForm,
                 isPartnership
               ))
@@ -81,7 +83,7 @@ class OrganisationDetailsController @Inject()(
           form.bindFromRequest().fold(
             formWithErrors => {
               Future.successful(
-                BadRequest(organisationDetailsView(formWithErrors, isPartnership))
+                BadRequest(organisationDetailsView(createPostCall, formWithErrors, isPartnership))
               )
             },
             data => {

--- a/app/controllers/TradingDetailsController.scala
+++ b/app/controllers/TradingDetailsController.scala
@@ -20,7 +20,7 @@ import com.google.inject.Inject
 import config.AppConfig
 import models.TradingDetails
 import play.api.i18n.MessagesApi
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents, MessagesRequest}
 import play.api.{Configuration, Environment}
 import repositories.LisaCacheRepository
 import services.AuthorisationService
@@ -43,8 +43,8 @@ class TradingDetailsController @Inject()(
   val get: Action[AnyContent] = Action.async { implicit request =>
     authorisedForLisa { _ =>
       sessionCacheRepository.getFromSession[TradingDetails](DataKey(TradingDetails.cacheKey)).map {
-        case Some(data) => Ok(tradingDetailsView(TradingDetails.form.fill(data)))
-        case None => Ok(tradingDetailsView(TradingDetails.form))
+        case Some(data) => Ok(tradingDetailsView(createPostCall, TradingDetails.form.fill(data)))
+        case None => Ok(tradingDetailsView(createPostCall, TradingDetails.form))
       }
     }
   }
@@ -53,7 +53,7 @@ class TradingDetailsController @Inject()(
     authorisedForLisa { _ =>
       TradingDetails.form.bindFromRequest().fold(
         formWithErrors => {
-          Future.successful(BadRequest(tradingDetailsView(formWithErrors)))
+          Future.successful(BadRequest(tradingDetailsView(createPostCall, formWithErrors)))
         },
         data => {
           sessionCacheRepository.putSession[TradingDetails](DataKey(TradingDetails.cacheKey), TradingDetails.uppercaseZ(data)).flatMap { _ =>

--- a/app/controllers/YourDetailsController.scala
+++ b/app/controllers/YourDetailsController.scala
@@ -43,8 +43,8 @@ class YourDetailsController @Inject()(
   val get: Action[AnyContent] = Action.async { implicit request =>
     authorisedForLisa { _ =>
       sessionCacheRepository.getFromSession[YourDetails](DataKey(YourDetails.cacheKey)).map {
-        case Some(data) => Ok(yourDetailsView(YourDetails.form.fill(data)))
-        case None => Ok(yourDetailsView(YourDetails.form))
+        case Some(data) => Ok(yourDetailsView(createPostCall, YourDetails.form.fill(data)))
+        case None => Ok(yourDetailsView(createPostCall, YourDetails.form))
       }
 
     }
@@ -55,7 +55,7 @@ class YourDetailsController @Inject()(
 
       YourDetails.form.bindFromRequest().fold(
         formWithErrors => {
-          Future.successful(BadRequest(yourDetailsView(formWithErrors)))
+          Future.successful(BadRequest(yourDetailsView(createPostCall, formWithErrors)))
         },
         data => {
           sessionCacheRepository.putSession[YourDetails](DataKey(YourDetails.cacheKey), data).flatMap { _ =>

--- a/app/views/registration/business_structure.scala.html
+++ b/app/views/registration/business_structure.scala.html
@@ -27,7 +27,7 @@
         formHelper: FormWithCSRF
      )
 
-@(form: Form[BusinessStructure])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+@(call: Call, form: Form[BusinessStructure])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
 @govukWrapper(title = if(form.hasErrors) messages("error.title", messages("title.business-structure")) else messages("title.business-structure")) {
 
@@ -42,7 +42,7 @@
         @govukErrorSummary(ErrorSummary(errorList = form.errors.asTextErrorLinks, title = Text(messages("validation.summary.heading"))))
     }
 
-    @formHelper(action = controllers.routes.BusinessStructureController.post) {
+    @formHelper(action = call) {
         <div class='form-group @if(form("companyStructure").hasErrors) {form-field--error}'>
                 @govukRadios(Radios(
                     fieldset = Some(Fieldset(

--- a/app/views/registration/organisation_details.scala.html
+++ b/app/views/registration/organisation_details.scala.html
@@ -28,7 +28,7 @@
         formHelper: FormWithCSRF
      )
 
-@(form: Form[OrganisationDetails], isPartnership: Boolean)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+@(call: Call, form: Form[OrganisationDetails], isPartnership: Boolean)(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
 @utrName = @{if(isPartnership) {
         "str"
@@ -66,7 +66,7 @@
         @govukErrorSummary(ErrorSummary(errorList = form.errors.asTextErrorLinks, title = Text(messages("validation.summary.heading"))))
     }
 
-    @formHelper(action = controllers.routes.OrganisationDetailsController.post) {
+    @formHelper(action = call) {
 
         <h1 class="govuk-heading-l">@messages("org.details.heading")</h1>
         @govukInput(Input(

--- a/app/views/registration/trading_details.scala.html
+++ b/app/views/registration/trading_details.scala.html
@@ -28,7 +28,7 @@
         formHelper: FormWithCSRF
         )
 
-@(form: Form[TradingDetails])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+@(call: Call, form: Form[TradingDetails])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
 @govukWrapper(title = if(form.hasErrors) messages("error.title", messages("title.trading-details")) else messages("title.trading-details")) {
 
@@ -48,7 +48,7 @@
         )
     }
 
-    @formHelper(action = controllers.routes.TradingDetailsController.post) {
+    @formHelper(action = call) {
 
         <h1 class="govuk-heading-l">@messages("tradingdetails.heading")</h1>
         @govukInput(Input(

--- a/app/views/registration/your_details.scala.html
+++ b/app/views/registration/your_details.scala.html
@@ -29,7 +29,7 @@
         formHelper: FormWithCSRF
         )
 
-@(form: Form[YourDetails])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+@(call: Call, form: Form[YourDetails])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
 @govukWrapper(title = if(form.hasErrors) messages("error.title", messages("title.your-details")) else messages("title.your-details")) {
 
@@ -49,7 +49,7 @@
         content = Text(messages("yourdetails.indent"))
     ))
 
-    @formHelper(action = controllers.routes.YourDetailsController.post) {
+    @formHelper(action = call) {
 
         @govukInput(Input(
             id = "firstName",


### PR DESCRIPTION
[lisa-browser-tests](https://build.tax.service.gov.uk/job/DDCE%20Live%20Services/job/LISA/job/lisa-browser-tests/141/) `FAILED` in Jenkins, the redirect back to the Summary page when editing a field in the Summary was not working correctly.

Successful run of tests locally using these changes:
![Screenshot 2024-05-31 at 14 33 07](https://github.com/hmrc/lisa-frontend/assets/125281117/3f72141b-71ec-47a7-b0d4-add37f10fa87)
